### PR TITLE
Add an access count for last 24 hours.

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ const client = new Redis({
 // Function to hash long URL to a fixed length short code
 function hashLongUrl(longUrl) {
   // Using SHA-256 and slicing to get a shorter part of the hash
-  return crypto.createHash('sha256').update(longUrl).digest('hex').slice(0, 6);
+  return crypto.createHash('sha256').update(longUrl).digest('hex').slice(0, 10);
 }
 
 // Helper function to get ISO week number
@@ -72,6 +72,16 @@ app.get('/:shortCode', async (req, res) => {
     // Increment the total access count
     await client.incr(`accessCount:total:${shortCode}`);
 
+    // Get current date and time in YYYY-MM-DD-HH-mm format for minute count
+    const minuteKey = new Date().toISOString().slice(0, 16);
+
+    // Increment minute access count
+    const minuteAccessKey = `accessCount:minute:${shortCode}:${minuteKey}`;
+    await client.incr(minuteAccessKey);
+    
+    // Set the minute key to expire after 24 hours
+    await client.expire(minuteAccessKey, 86400); 
+
     // Get current date in YYYY-MM-DD format for daily count
     const today = new Date().toISOString().split('T')[0];
     // Increment daily access count
@@ -103,11 +113,21 @@ app.get('/stats/:shortCode', async (req, res) => {
     const dailyAccesses = await client.hgetall(`accessCount:daily:${shortCode}`);
     const weeklyAccesses = await client.hgetall(`accessCount:weekly:${shortCode}`);
 
+    // Fetch minute counts for the last 24 hours
+    // const currentMinute = new Date().toISOString().slice(0, 16);
+    let last24HourAccesses = 0;
+    for (let i = 0; i < 1440; i++) { // 1440 minutes in 24 hours
+      const minuteOffset = new Date(new Date().setMinutes(new Date().getMinutes() - i)).toISOString().slice(0, 16);
+      const minuteCount = await client.get(`accessCount:minute:${shortCode}:${minuteOffset}`) || 0;
+      last24HourAccesses += parseInt(minuteCount);
+    }
+
     res.json({
       shortCode,
       totalAccesses,
-      dailyAccesses,
       weeklyAccesses,
+      dailyAccesses,
+      last24HourAccesses,
     });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
What?
Adding an access count for last 24 hours.

Why?
Cool feature request by Tom Paulus.

How?
Implements minute "buckets". Each bucket has a "minutekey" which holds the access count for that minute. We reset buckets to 0 every 24 hours. there are 1440  "buckets" in a day (24 * 60).
